### PR TITLE
[#21] スキーマ/Annotated CRF/ Blank CRFのファイル名に対応したい

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .DS_Store
 app
 yarn-error.log
+.vscode


### PR DESCRIPTION
#21 
- ```URL,相対パス```の形式のレスポンスが来た時は保存フォルダ、ファイル名を変更する
  - ファイル名を```相対パス```にして保存
  - ファイル名として使用できない記号は```_```に変換
  - 上のディレクトリに保存できないように```../```を変換

フォルダがなければ作成する、はすでに対応済です。

@katsusuke 確認をお願いします。